### PR TITLE
WAV export format, resync and more annotation/display data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,4 +33,14 @@ To find the setting:
 
 Now, reload Logic and select **PDM** from the Analyzer drop down.
 
-Please see the [Sample Analyzer](https://github.com/saleae/SampleAnalyzer/blob/master/readme.md) for detailed build instructions.
+Please see the [Sample Analyzer](https://github.com/saleae/SampleAnalyzer/blob/master/readme.md) 
+for detailed build instructions.
+
+## Exporting as WAV audio files & logic2
+
+Not for Logic2 -- the ability for Analysers to export to (custom) files was somehow broken/lost 
+in the Logic 1 to 2 transition.
+
+As a work around - this version allows you to select the file export format in settings (so not 
+during the export itself). You then use the (now only) available `export as CSV/text' option
+which will, in fact, save the file as the format specified (e.g. WAV or raw PCM).

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,16 @@ This analyzer is useful for PDM streams. It counts the number of 1s present on
 the data line for a given clock's rising edges. In PDM terms, that means it only
 does the first channel. It doesn't handle stereo currently.
 
+## Sync
+
 It does its best to start with the clock signal. However, it may be shifted
 against the samples you receive in your code. Changing the bits per sample
 configuration sample to 1 can make it easy to read individual bits instead of the
 ones count for a set of bits.
+
+Alternatively - you can specify an optional 'sync' channel; which will reset
+the count to 0 upon going low. This makes byte or word by word comparisons
+easier.
 
 # Using
 

--- a/source/PDMAnalyzer.cpp
+++ b/source/PDMAnalyzer.cpp
@@ -36,46 +36,55 @@ void PDMAnalyzer::WorkerThread()
 	// Find the start of a low.
 	if( mClock->GetBitState() == BIT_HIGH ) {
 		mClock->AdvanceToNextEdge();
-	} else {
+	} 
+#if 0
+	else {
 		mClock->AdvanceToNextEdge();
 		mClock->AdvanceToNextEdge();
 	}
-
 	U64 low_start = mClock->GetSampleNumber();
 	U64 low_duration = 0;
 	U64 high_duration = 0;
 	mClock->AdvanceToNextEdge();
-	while (low_duration == 0 || abs(low_duration - high_duration) > (low_duration + high_duration) / 2) {
+	while (low_duration == 0 || std::abs((long long)(low_duration - high_duration)) > (low_duration + high_duration) / 2) {
 		mClock->AdvanceToNextEdge(); // Falling edge
 		low_start = mClock->GetSampleNumber();
 		mClock->AdvanceToNextEdge(); // Rising edge
 		low_duration = mClock->GetSampleNumber() - low_start;
 		high_duration = mClock->GetSampleOfNextEdge() - mClock->GetSampleNumber();
 	}
-
+#endif
 
 	for( ; ; )
 	{
 		U8 data = 0;
 
 		U64 starting_sample = mClock->GetSampleNumber();
-
-		//let's put a dot exactly where we sample this bit:
-		mResults->AddMarker( mClock->GetSampleNumber(), AnalyzerResults::Dot, mSettings->mDataChannel );
+		mResults->AddMarker( mClock->GetSampleNumber(), AnalyzerResults::Dot, mSettings->mDataChannel);
 
 		for( U32 i=0; i< mSettings->mBitsPerSample; i++ )
 		{
+			mResults->AddMarker( mClock->GetSampleNumber(), 
+				(i) ? AnalyzerResults::DownArrow : AnalyzerResults::Dot, mSettings->mClockChannel);
+
 			mData->AdvanceToAbsPosition(mClock->GetSampleNumber());
 
-			if( mData->GetBitState() == BIT_HIGH )
-				data++;
+			bool isHigh = ( mData->GetBitState() == BIT_HIGH );
+			if (isHigh) data++;
 
+			U64 s = mClock->GetSampleNumber();
 			// Next falling edge.
 			// TODO(tannewt): Support stereo data by reading the data here.
 			mClock->AdvanceToNextEdge();
 
+			// Place the one in the middle of this low; alternative is getting it about
+			// 20-30 nanosconds after the down.
+			U64 e = mClock->GetSampleNumber();
+			mResults->AddMarker((s+e)/2, isHigh ? AnalyzerResults::One : AnalyzerResults::Zero, mSettings->mDataChannel );
+
 			// Next rising edge.
 			mClock->AdvanceToNextEdge();
+
 		}
 
 

--- a/source/PDMAnalyzer.h
+++ b/source/PDMAnalyzer.h
@@ -26,6 +26,7 @@ protected: //vars
 	std::auto_ptr< PDMAnalyzerResults > mResults;
 	AnalyzerChannelData* mClock;
 	AnalyzerChannelData* mData;
+	AnalyzerChannelData* mSync;
 
 	PDMSimulationDataGenerator mSimulationDataGenerator;
 	bool mSimulationInitilized;

--- a/source/PDMAnalyzerResults.cpp
+++ b/source/PDMAnalyzerResults.cpp
@@ -4,6 +4,8 @@
 #include "PDMAnalyzerSettings.h"
 #include <iostream>
 #include <fstream>
+#include <sstream>
+#include <algorithm>
 
 PDMAnalyzerResults::PDMAnalyzerResults( PDMAnalyzer* analyzer, PDMAnalyzerSettings* settings )
 :	AnalyzerResults(),
@@ -16,13 +18,29 @@ PDMAnalyzerResults::~PDMAnalyzerResults()
 {
 }
 
+void  PDMAnalyzerResults::getValue(Frame frame, DisplayBase display_base, char * number_str, size_t result_len) 
+{
+        U8 data = frame.mData1 + (mSettings->mSignedValues) ? (-mSettings->mBitsPerSample / 2) : 0;
+
+        if (display_base == Decimal && mSettings->mSignedValues) {
+            S64 signed_number = AnalyzerHelpers::ConvertToSignedNumber( data, 8);
+            std::stringstream ss;
+            ss << signed_number;
+            strncpy( number_str, ss.str().c_str(), result_len); 
+	    number_str[result_len-1] = '\0'; // strncpy does not \0 terminate if the result is >= n in length.
+        } else {
+	    AnalyzerHelpers::GetNumberString( data, display_base, 8, number_str, result_len);
+        };
+}
+
 void PDMAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& channel, DisplayBase display_base )
 {
 	ClearResultStrings();
 	Frame frame = GetFrame( frame_index );
-
+		
 	char number_str[128];
-	AnalyzerHelpers::GetNumberString( frame.mData1, display_base, 8, number_str, 128 );
+	getValue(frame, display_base, number_str, sizeof(number_str));
+
 	AddResultString( number_str );
 }
 
@@ -32,29 +50,145 @@ void PDMAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displ
 
 	U64 trigger_sample = mAnalyzer->GetTriggerSample();
 	U32 sample_rate = mAnalyzer->GetSampleRate();
-
-	file_stream << "Time [s],Value" << std::endl;
-
 	U64 num_frames = GetNumFrames();
-	for( U32 i=0; i < num_frames; i++ )
-	{
-		Frame frame = GetFrame( i );
-		
-		char time_str[128];
-		AnalyzerHelpers::GetTimeString( frame.mStartingSampleInclusive, trigger_sample, sample_rate, time_str, 128 );
 
-		char number_str[128];
-		AnalyzerHelpers::GetNumberString( frame.mData1, display_base, 8, number_str, 128 );
+#if 2 // Logic2 broke/retired the GenerateExport file selection options - so we take the configured value for now.
+	export_type_user_id = mSettings->mExportFormat;
+#endif
+        if (export_type_user_id == PDMAnalyzerSettings::FORMAT_WAV) {
+		// WAV file
+ 
+		U32 file_len = 44 + num_frames;
+		U32 channels = 1;
+		U32 bitsPerSample = 8;
 
-		file_stream << time_str << "," << number_str << std::endl;
+        	S64 from = GetFrame(0).mEndingSampleInclusive;
+	        S64 till = GetFrame(num_frames - 1).mStartingSampleInclusive;
+		double duration = (till - from) / sample_rate;
+		U32 audioSampleRate = num_frames / duration;
 
-		if( UpdateExportProgressAndCheckForCancel( i, num_frames ) == true )
+		// Source: https://github.com/audiojs/sample-rate under the MIT license
+		U32 normalRates[] = { 
+			8000, //	 Hz	Adequate for human speech but without sibilance. Used in telephone/walkie-talkie.
+			11025, //	 Hz	Used for lower-quality PCM, MPEG audio and for audio analysis of subwoofer bandpasses.
+			16000, //	 Hz	Used in most VoIP and VVoIP, extension of telephone narrowband.
+			22050, //	 Hz	Used for lower-quality PCM and MPEG audio and for audio analysis of low frequency energy.
+			44100, //	 Hz	Audio CD, most commonly used rate with MPEG-1 audio (VCD, SVCD, MP3). Covers the 20 kHz bandwidth.
+			48000, //	 Hz	Standard sampling rate used by professional digital video equipment, could reconstruct frequencies up to 22 kHz.
+			88200, //	 Hz	Used by some professional recording equipment when the destination is CD, such as mixers, EQs, compressors, reverb, crossovers and recording devices.
+			96000, //	 Hz	DVD-Audio, LPCM DVD tracks, Blu-ray audio tracks, HD DVD audio tracks.
+			176400, //	 Hz	Used in HDCD recorders and other professional applications for CD production.
+			192000, //	 Hz	Used with audio on professional video equipment. DVD-Audio, LPCM DVD tracks, Blu-ray audio tracks, HD DVD audio tracks.
+			352800, //	 Hz	Digital eXtreme Definition. Used for recording and editing Super Audio CDs.
+			384000, //	 Hz	Highest sample rate available for common software. Allows for precise peak detection.
+			0
+		};
+		// Check if we are within 5% of any of the well known rates; and adjust to that value.
+		//
+		for(int i = 0; normalRates[i]; i++) {
+			double delta = fabsl(normalRates[i]-audioSampleRate)/std::min(normalRates[i],audioSampleRate);
+			if (delta < 0.025) {
+				audioSampleRate = normalRates[i];
+				break;
+			};
+		};
+
+		file_stream.write("RIFF",4); // WAV/RIFF header					0,4
 		{
-			file_stream.close();
-			return;
-		}
-	}
+			U32 tmp = file_len - 8; // Chunk Size
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	4,4
+		};
+		file_stream.write("WAVE",4);						//	8,4
 
+		file_stream.write( "fmt ",4); // Start chunk					12,4
+		{
+			U32 tmp = 16; // length of this chunk
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	16,4
+		};
+		{
+			U16 tmp = 1; // PCM format
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	20,3
+		};
+		{
+			U16 tmp = channels; // mono / 1 channel
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	22,2
+		};
+		{
+			U32 tmp = audioSampleRate; // sample rate
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	24,4
+		};
+		{
+			U32 tmp = audioSampleRate * bitsPerSample * channels / 8; // byte rate
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	28,4
+		};
+		{
+			U16 tmp = bitsPerSample * channels / 8; // bytes/block/align
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	32,2	
+		};
+		{
+			U16 tmp = bitsPerSample; // bits per sample
+			file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	34,2
+		};
+		file_stream.write("data",4); // start of the sample for this cunk		36,4	
+		{
+			U32 tmp = num_frames; // number of bytes
+	                file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));//	40,4
+		};
+
+		for( U32 i=0; i < num_frames; i++ ) {
+			Frame frame = GetFrame( i );
+			U8 tmp = frame.mData1;
+			// Centre of the values of 0..Q(inc) is at Q/2; move this
+			// to 127 -- the center of 0..255; and scale to 40%
+			//
+			if (mSettings->mBitsPerSample < 255) {
+				tmp *= 0.40 * 255/mSettings->mBitsPerSample;
+				tmp += (255 - mSettings->mBitsPerSample)/2;
+			};
+	                file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));
+			if( UpdateExportProgressAndCheckForCancel( i, num_frames ) == true )
+			{
+				file_stream.close();
+				return;
+			};
+		};
+	} else if (export_type_user_id == PDMAnalyzerSettings::FORMAT_PCM) { 
+		// PCM file - as raw as raw can be - so we do not attempt
+		// to recenter the bytes.
+		//
+		for( U32 i=0; i < num_frames; i++ ) {
+			Frame frame = GetFrame( i );
+			U8 tmp = frame.mData1;
+	                file_stream.write(reinterpret_cast<const char*>(&tmp),sizeof(tmp));
+			if( UpdateExportProgressAndCheckForCancel( i, num_frames ) == true )
+			{
+				file_stream.close();
+				return;
+			};
+		};
+        } else  // PDMAnalyzerSettings::FORMAT_CSV / text
+	{
+		file_stream << "Time [s],Value" << std::endl;
+
+		for( U32 i=0; i < num_frames; i++ )
+		{
+			Frame frame = GetFrame( i );
+			
+			char time_str[128];
+			AnalyzerHelpers::GetTimeString( frame.mStartingSampleInclusive, trigger_sample, sample_rate, time_str, 128 );
+	
+			char number_str[128];
+		        getValue(frame, display_base, number_str, sizeof(number_str));
+	
+			file_stream << time_str << "," << number_str << std::endl;
+	
+			if( UpdateExportProgressAndCheckForCancel( i, num_frames ) == true )
+			{
+				file_stream.close();
+				return;
+			};
+		};
+        }
 	file_stream.close();
 }
 
@@ -65,7 +199,8 @@ void PDMAnalyzerResults::GenerateFrameTabularText( U64 frame_index, DisplayBase 
 	ClearTabularText();
 
 	char number_str[128];
-	AnalyzerHelpers::GetNumberString( frame.mData1, display_base, 8, number_str, 128 );
+	getValue(frame, display_base, number_str, sizeof(number_str));
+
 	AddTabularText( number_str );
 #endif
 }

--- a/source/PDMAnalyzerResults.h
+++ b/source/PDMAnalyzerResults.h
@@ -24,6 +24,9 @@ protected: //functions
 protected:  //vars
 	PDMAnalyzerSettings* mSettings;
 	PDMAnalyzer* mAnalyzer;
+
+private:
+        virtual void getValue(Frame frame, DisplayBase display_base, char * result_str, size_t result_len);
 };
 
 #endif //PDM_ANALYZER_RESULTS

--- a/source/PDMAnalyzerSettings.cpp
+++ b/source/PDMAnalyzerSettings.cpp
@@ -15,23 +15,51 @@ PDMAnalyzerSettings::PDMAnalyzerSettings()
 	mDataChannelInterface->SetTitleAndTooltip( "Data", "PDM Clock" );
 	mDataChannelInterface->SetChannel( mDataChannel );
 
+	mSyncChannelInterface.reset( new AnalyzerSettingInterfaceChannel() );
+	mSyncChannelInterface->SetTitleAndTooltip( "Reset (optional)", "PDM count reset/sync (optional, resets bitcount to 0)" );
+	mSyncChannelInterface->SetChannel( mSyncChannel );
+	mSyncChannelInterface->SetSelectionOfNoneIsAllowed( true );
+
 	mBitsPerSampleInterface.reset( new AnalyzerSettingInterfaceInteger() );
-	mBitsPerSampleInterface->SetTitleAndTooltip( "Bits per sample",  "Specify the number of individual bits that form a sample." );
+	mBitsPerSampleInterface->SetTitleAndTooltip( "Bits per sample (Q)",  "Specify the number of individual bits that form a sample." );
 	mBitsPerSampleInterface->SetMax( 255 );
 	mBitsPerSampleInterface->SetMin( 1 );
 	mBitsPerSampleInterface->SetInteger( mBitsPerSample );
 
+	mSignedValuesInterface.reset( new AnalyzerSettingInterfaceBool() );
+	mSignedValuesInterface->SetTitleAndTooltip( "Display as signed",  "Display the count as signed integers (e.g. Audio) rather than hex; with the 0 around Q/2");
+	mSignedValuesInterface->SetValue(false );
+
+	mFileformatInterface.reset(new AnalyzerSettingInterfaceNumberList() );
+	mFileformatInterface->SetTitleAndTooltip( "Fileformat", "Fileformat on export, overwrites CSV/TEXT");
+	mFileformatInterface->AddNumber(FORMAT_CSV,"Export as text/CSV file","Export as text/CSV file");
+	mFileformatInterface->AddNumber(FORMAT_WAV,"Export as WAV file (mono, 8bits)","Export as WAV file, 8bits, mono and signed/unsigned depending on setting");
+	mFileformatInterface->AddNumber(FORMAT_PCM,"Export as PCM file (raw values as bytes)","Export as raw bytes; i.e. a series if raw bytes; as many as Q counts.");
+
 	AddInterface( mClockChannelInterface.get() );
 	AddInterface( mDataChannelInterface.get() );
 	AddInterface( mBitsPerSampleInterface.get() );
+	AddInterface( mSignedValuesInterface.get() );
+	AddInterface( mFileformatInterface.get() );
+	AddInterface( mSyncChannelInterface.get() );
 
-	AddExportOption( 0, "Export as text/csv file" );
-	AddExportExtension( 0, "text", "txt" );
-	AddExportExtension( 0, "csv", "csv" );
+
+	AddExportOption(FORMAT_CSV, "Export as text/CSV file" );
+	AddExportExtension(FORMAT_CSV, "text", "txt" );
+	AddExportExtension(FORMAT_CSV, "csv", "csv" );
+
+	AddExportOption(FORMAT_WAV, "Export as a WAV file" );
+	AddExportExtension(FORMAT_WAV, "PCM","pcm");
+	AddExportExtension(FORMAT_WAV, "U8","u8");
+	AddExportExtension(FORMAT_WAV, "Raw","raw");
+
+	AddExportOption(FORMAT_PCM, "Export as a raw PCM/bytes file" );
+	AddExportExtension(FORMAT_PCM, "WAV", "wav" );
 
 	ClearChannels();
 	AddChannel( mClockChannel, "Clock", false );
 	AddChannel( mDataChannel, "Data", false );
+	AddChannel( mSyncChannel, "Reset", false );
 }
 
 PDMAnalyzerSettings::~PDMAnalyzerSettings()
@@ -42,11 +70,15 @@ bool PDMAnalyzerSettings::SetSettingsFromInterfaces()
 {
 	mClockChannel = mClockChannelInterface->GetChannel();
 	mDataChannel = mDataChannelInterface->GetChannel();
+	mSyncChannel = mSyncChannelInterface->GetChannel();
 	mBitsPerSample = mBitsPerSampleInterface->GetInteger();
+        mSignedValues = mSignedValuesInterface->GetValue();
+        mExportFormat = (format_t) mFileformatInterface->GetNumber();
 
 	ClearChannels();
 	AddChannel( mClockChannel, "Clock", true );
 	AddChannel( mDataChannel, "Data", true );
+	AddChannel( mSyncChannel, "Reset", mSyncChannel != UNDEFINED_CHANNEL);
 
 	return true;
 }
@@ -55,7 +87,10 @@ void PDMAnalyzerSettings::UpdateInterfacesFromSettings()
 {
 	mClockChannelInterface->SetChannel( mClockChannel );
 	mDataChannelInterface->SetChannel( mDataChannel );
+	mSyncChannelInterface->SetChannel( mSyncChannel );
 	mBitsPerSampleInterface->SetInteger( mBitsPerSample );
+	mSignedValuesInterface->SetValue( mSignedValues );
+	mFileformatInterface->SetNumber( (int)mExportFormat );
 }
 
 void PDMAnalyzerSettings::LoadSettings( const char* settings )
@@ -64,12 +99,16 @@ void PDMAnalyzerSettings::LoadSettings( const char* settings )
 	text_archive.SetString( settings );
 
 	text_archive >> mClockChannel;
-    text_archive >> mDataChannel;
+        text_archive >> mDataChannel;
+        text_archive >> mSyncChannel;
 	text_archive >> mBitsPerSample;
+	text_archive >> mSignedValues;
+	text_archive >> mExportFormat;
 
 	ClearChannels();
 	AddChannel( mClockChannel, "Clock", true );
-    AddChannel( mDataChannel, "Data", true);
+        AddChannel( mDataChannel, "Data", true);
+	AddChannel( mSyncChannel, "Reset", mSyncChannel != UNDEFINED_CHANNEL);
 
 	UpdateInterfacesFromSettings();
 }
@@ -79,8 +118,11 @@ const char* PDMAnalyzerSettings::SaveSettings()
 	SimpleArchive text_archive;
 
 	text_archive << mClockChannel;
-    text_archive << mDataChannel;
+        text_archive << mDataChannel;
+        text_archive << mSyncChannel;
 	text_archive << mBitsPerSample;
+	text_archive << mSignedValues;
+	text_archive << mExportFormat;
 
 	return SetReturnString( text_archive.GetString() );
 }

--- a/source/PDMAnalyzerSettings.h
+++ b/source/PDMAnalyzerSettings.h
@@ -15,15 +15,23 @@ public:
 	virtual void LoadSettings( const char* settings );
 	virtual const char* SaveSettings();
 
-
 	Channel mClockChannel;
 	Channel mDataChannel;
+	Channel mSyncChannel;
 	U32 mBitsPerSample;
+	bool mSignedValues;
+        
+	typedef enum { FORMAT_CSV = 0, FORMAT_WAV = 1, FORMAT_PCM = 2 } format_t;
+	double mExportFormat;
 
 protected:
 	std::auto_ptr< AnalyzerSettingInterfaceChannel >	mClockChannelInterface;
 	std::auto_ptr< AnalyzerSettingInterfaceChannel >	mDataChannelInterface;
+	std::auto_ptr< AnalyzerSettingInterfaceChannel >	mSyncChannelInterface;
 	std::auto_ptr< AnalyzerSettingInterfaceInteger >	mBitsPerSampleInterface;
+	std::auto_ptr< AnalyzerSettingInterfaceBool >		mSignedValuesInterface;
+	std::auto_ptr< AnalyzerSettingInterfaceNumberList>	mFileformatInterface;
+
 };
 
 #endif //PDM_ANALYZER_SETTINGS


### PR DESCRIPTION
Suggestion for some improvements; 

1. Additional data shown -- see below
2. Ability to export WAV and PCM files (e.g. to check what the microphone hears)
3. A 'sync' option - to reset the Q-count - to make it easier to check for bit-count correctness in test patterns.
4. A signed/unsigned option - to make it easier to compare the output to code output

<img width="982" height="417" alt="Screenshot 2025-09-24 at 19 43 10" src="https://github.com/user-attachments/assets/bedb5952-4b3b-4d39-b976-2812934ca051" />
